### PR TITLE
Rename github token environment variable

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Publish
       if: github.event_name == 'push'
       env:
-        HYDROFRAME_BOT_TOKEN: ${{ secrets.HYDROFRAME_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.HYDROFRAME_BOT_TOKEN }}
       run: ./scripts/github-actions/publish_docs.sh

--- a/scripts/github-actions/publish_docs.sh
+++ b/scripts/github-actions/publish_docs.sh
@@ -3,6 +3,6 @@ set -ev
 
 git config --global user.name "hydroframe-bot"
 git config --global user.email "hydroframe.bot@gmail.com"
-export GIT_PUBLISH_URL=https://${HYDROFRAME_BOT_TOKEN}@github.com/hydroframe/SandTank.git
+export GIT_PUBLISH_URL=https://${GITHUB_TOKEN}@github.com/hydroframe/SandTank.git
 npm run semantic-release
 npm run doc:publish


### PR DESCRIPTION
semantic-release specificaly looks for "GITHUB_TOKEN" or "GH_TOKEN" in the environment. We need to use one of these.