### PR TITLE
fix(semantic-release): run CI when git tag is pushed

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,7 +4,9 @@
     "@semantic-release/release-notes-generator",
     ["@semantic-release/npm",{"npmPublish":false}],
     "@semantic-release/changelog",
-    "@semantic-release/git"
+    ["@semantic-release/git", {
+      "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+    }]
   ],
   "branch": "master"
 }


### PR DESCRIPTION
By default, semantic-release disables the CI when it pushes a tag in order to prevent a needless CI
from running. However, we want the CI to run so that a tagged docker image will get pushed as well.

Remove `[skip ci]` from the default commit message from semantic-release, so that the CI will be
ran.
```
"message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
```