### PR TITLE
fix(semantic-release): set git environment variables

### DIFF
--- a/scripts/github-actions/publish_docs.sh
+++ b/scripts/github-actions/publish_docs.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 set -ev
 
-git config --global user.name "hydroframe-bot"
-git config --global user.email "hydroframe.bot@gmail.com"
+BOT_NAME="hydroframe-bot"
+BOT_EMAIL="hydroframe.bot@gmail.com"
+
+git config --global user.name "$BOT_NAME"
+git config --global user.email "$BOT_EMAIL"
 export GIT_PUBLISH_URL=https://${GITHUB_TOKEN}@github.com/hydroframe/SandTank.git
+
+# Environment variables for semantic-release
+export GIT_AUTHOR_NAME=$BOT_NAME
+export GIT_AUTHOR_EMAIL=$BOT_EMAIL
+export GIT_COMMITTER_NAME=$BOT_NAME
+export GIT_COMMITTER_EMAIL=$BOT_EMAIL
+
 npm run semantic-release
 npm run doc:publish


### PR DESCRIPTION
This will modify the name/email of the committer from semantic-release-bot to hydroframe-bot, [according to the documentation](https://semantic-release.gitbook.io/semantic-release/usage/configuration#git-environment-variables).

Additionally, according to the [github authentication documentation for semantic-release](https://github.com/semantic-release/github#github-authentication), the use of GITHUB_TOKEN will not trigger another action,which prevents us from triggering a docker push when a new git tag is pushed by semantic-release. However, it might be talking about the github-provided GITHUB_TOKEN rather than the one we are setting. So I'm not sure if it makes a difference, but we are going to give GH_TOKEN a try.