### PR TITLE
fix(semantic-release): use the github plugin to publish releases

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,6 @@
 {
   "plugins": [
+    "@semantic-release/github",
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/npm",{"npmPublish":false}],


### PR DESCRIPTION
This is required for the docker build to be triggered. Otherwise, a release won't get published, and
the docker build won't be triggered.