### PR TITLE
docs(semantic-release): update Docker readme badge on publish

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,6 +5,9 @@
     "@semantic-release/release-notes-generator",
     ["@semantic-release/npm",{"npmPublish":false}],
     "@semantic-release/changelog",
+    ["@semantic-release/exec", {
+      "prepareCmd": "./scripts/semantic-release/update_readme_badge.sh ${lastRelease.version} ${nextRelease.version}"
+    }],
     ["@semantic-release/git", {
       "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
     }]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ParFlow Sandtank
 
-[![Docker](https://github.com/hydroframe/SandTank/workflows/Docker/badge.svg?branch=master)](https://github.com/hydroframe/SandTank/actions?query=workflow%3ADocker+branch%3Amaster)
+[![Docker](https://github.com/hydroframe/SandTank/workflows/Docker/badge.svg?event=release&branch=v1.0.6)](https://github.com/hydroframe/SandTank/actions?query=workflow%3ADocker+event%3Arelease)
 [![Docs](https://github.com/hydroframe/SandTank/workflows/Docs/badge.svg?branch=master)](https://github.com/hydroframe/SandTank/actions?query=workflow%3ADocs+branch%3Amaster)
 
 This application aims to provide a standalone solution for simulating a specific Sand tank setup using ParFlow and an interactive Web UI for adjusting the various parameters that can be adjusted by the user.

--- a/package-lock.json
+++ b/package-lock.json
@@ -360,6 +360,45 @@
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
       "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg=="
     },
+    "@semantic-release/exec": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-5.0.0.tgz",
+      "integrity": "sha512-t7LWXIvDJQbuGCy2WmMG51WyaGSLTvZBv9INvcI4S0kn+QjnnVVUMhcioIqhb0r3yqqarMzHVcABFug0q0OXjw==",
+      "requires": {
+        "@semantic-release/error": "^2.1.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^4.0.0",
+        "lodash": "^4.17.4",
+        "parse-json": "^5.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        }
+      }
+    },
     "@semantic-release/git": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-9.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Interactively simulate and visualize groundwater movement",
   "dependencies": {
     "@semantic-release/changelog": "^5.0.1",
+    "@semantic-release/exec": "^5.0.0",
     "@semantic-release/git": "^9.0.0",
     "commitizen": "^4.0.4",
     "semantic-release": "^17.0.7"

--- a/scripts/semantic-release/update_readme_badge.sh
+++ b/scripts/semantic-release/update_readme_badge.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# $1 should be the last version, and $2 should be the new version
+
+sed -i "s/branch=v$1/branch=v$2/g" README.md
+git add README.md
+
+# @semantic-release/git will commit this change later


### PR DESCRIPTION
Unfortunately, the Docker README.md badge needs to be pointing to the specific release that just
came out (for instance, `v1.0.1`). Otherwise, it won't work. To fix it, we will run a script that
uses sed to modify the version number in the README file.

Fixes: #12